### PR TITLE
Add Jest tests for Express server

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "strattopay-backend",
   "version": "1.0.0",
   "description": "Strattopay is a secure, scalable remittance platform that allows users to send money globally with live currency conversion and gamified reward features.",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
     "test": "jest",
     "start": "node server.js"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "strattopay-backend",
+  "version": "1.0.0",
+  "description": "Strattopay is a secure, scalable remittance platform that allows users to send money globally with live currency conversion and gamified reward features.",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.6.1"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const app = express();
+
+app.get('/', (req, res) => {
+  res.json({message: 'Welcome to Strattopay Backend'});
+});
+
+if (require.main === module) {
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,24 @@
+const http = require('http');
+const app = require('../server');
+let server;
+
+beforeAll(done => {
+  server = app.listen(0, done);
+});
+
+afterAll(done => {
+  server.close(done);
+});
+
+test('GET / returns expected JSON', done => {
+  const { port } = server.address();
+  http.get({ port, path: '/' }, res => {
+    expect(res.statusCode).toBe(200);
+    let data = '';
+    res.on('data', chunk => data += chunk);
+    res.on('end', () => {
+      expect(JSON.parse(data)).toEqual({ message: 'Welcome to Strattopay Backend' });
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- initialize npm package
- implement a simple Express server
- add Jest and testing script
- create Jest test for the server

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840638432a883338b069a83cd25b049