### PR TITLE
Add initial Express server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "strattopay-backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+  res.json({ message: 'Welcome to Strattopay Backend!' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create server.js with an Express server
- add package.json with express dependency and start script

## Testing
- `node server.js` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68406365f76c8333b1ce6051b3f9d8ae