### PR TITLE
Initialize Node.js backend with Express

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "strattopay-backend",
+  "version": "1.0.0",
+  "description": "Strattopay is a secure, scalable remittance platform that allows users to send money globally with live currency conversion and gamified reward features.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node src/server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "dotenv": "^16.0.3"
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+  res.send('Server is running');
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- initialize `package.json` via `npm init`
- set up start script and add `express`/`dotenv` dependencies
- add basic Express server in `src/server.js`

## Testing
- `npm install` *(fails: 403 Forbidden because registry cannot be reached)*

------
https://chatgpt.com/codex/tasks/task_e_68539dd360388333a6347e0481e5d95c